### PR TITLE
[課題2] memcpyの実装

### DIFF
--- a/Classes/Example/Example2/Example2.cpp
+++ b/Classes/Example/Example2/Example2.cpp
@@ -15,8 +15,15 @@ std::string Example2::calcAnswer()
     char buf1[10];
     size_t size = 5;
 
+    // 確認用
+    int b1 = (unsigned)buf1 % 4;
+    int b2 = (unsigned)buf2 % 4;
+    printf("buf1は %d\n", b1);
+    printf("buf2は %d\n", b2);
+
     int c = 0;
     copyMemory(buf1, buf2, size, &c);
+    printf("%d\n", c);
 
     _answer = buf1;
 
@@ -34,9 +41,9 @@ void Example2::copyMemory(void *dst, const void *src, size_t size, int *c)
                   "B Loop \t\n"
 
                   "Loop1:"
-                    "LDR r1, [%[c]] \t\n"
-                    "ADD r1, r1, #1 \t\n"
-                    "STR r1, [%[c]] \t\n"
+                    "LDR r2, [%[c]] \t\n"
+                    "ADD r2, r2, #1 \t\n"
+                    "STR r2, [%[c]] \t\n"
 
                     "LDRB r0, [%[src]], #1 \t\n"
                     "STRB r0, [%[dst]], #1 \t\n"
@@ -44,9 +51,9 @@ void Example2::copyMemory(void *dst, const void *src, size_t size, int *c)
                     "B Loop \t\n"
 
                   "Loop2:"
-                    "LDR r1, [%[c]] \t\n"
-                    "ADD r1, r1, #20 \t\n"
-                    "STR r1, [%[c]] \t\n"
+                    "LDR r2, [%[c]] \t\n"
+                    "ADD r2, r2, #20 \t\n"
+                    "STR r2, [%[c]] \t\n"
 
                     "LDRH r0, [%[src]], #2 \t\n"
                     "STRH r0, [%[dst]], #2 \t\n"
@@ -54,9 +61,9 @@ void Example2::copyMemory(void *dst, const void *src, size_t size, int *c)
                     "B Loop \t\n"
 
                   "Loop4:"
-                    "LDR r1, [%[c]] \t\n"
-                    "ADD r1, r1, #40 \t\n"
-                    "STR r1, [%[c]] \t\n"
+                    "LDR r2, [%[c]] \t\n"
+                    "ADD r2, r2, #400 \t\n"
+                    "STR r2, [%[c]] \t\n"
 
                     "LDR r0, [%[src]], #4 \t\n"
                     "STR r0, [%[dst]], #4 \t\n"
@@ -64,14 +71,25 @@ void Example2::copyMemory(void *dst, const void *src, size_t size, int *c)
                     "B Loop \t\n"
 
                   "Loop:"
+                  "Label_load4:"
                     "CMP %[size], #4 \t\n"
-                    "BGE Loop4 \t\n"
+                    "BLT Label_load2 \t\n"
+
+                    "ANDS r1, %[src], 0x3 \t\n"
+                    "BEQ Loop4 \t\n"
+
+                  "Label_load2:"
                     "CMP %[size], #2 \t\n"
-                    "BGE Loop2 \t\n"
+                    "BLT Label_load1 \t\n"
+
+                    "ANDS r1, %[src], 0x1 \t\n"
+                    "BEQ Loop2 \t\n"
+
+                  "Label_load1:"
                     "CMP %[size], #1 \t\n"
                     "BGE Loop1 \t\n"
                   :[dst]"+r"(dst), [src]"+r"(src), [size]"+r"(size)
                   :[c]"r"(c)
-                  :"r0", "r1"
+                  :"r0", "r1", "r2"
                   );
 }

--- a/Classes/Example/Example2/Example2.cpp
+++ b/Classes/Example/Example2/Example2.cpp
@@ -31,5 +31,20 @@ std::string& Example2::calcAnswer()
 
 void Example2::copyMemory(void *dst, const void *src, size_t size)
 {
-    memcpy(dst, src, size);
+    /************************************
+     *  memcpy(dst, src, size);
+     ************************************/
+    asm volatile (
+                  "Loop:"
+                    "LDR r0, [%[src]] \t\n"               // srcの値をr0にロード
+                    "STR r0, [%[dst]] \t\n"               // r0をdstにストア
+                    "ADD %[src], %[src], #1 \t\n"         // src++;
+                    "ADD %[dst], %[dst], #1 \t\n"         // dst++;
+                    "SUB %[size], %[size], #1 \t\n"       // size--;
+                    "CMP %[size], #0 \t\n"
+                    "BNE Loop \t\n"                       // size != 0 がtrueならloopラベルにジャンプ
+                  :[dst]"+r"(dst), [src]"+r"(src), [size]"+r"(size)
+                  :
+                  :"r0"
+                  );
 }

--- a/Classes/Example/Example2/Example2.cpp
+++ b/Classes/Example/Example2/Example2.cpp
@@ -15,15 +15,7 @@ std::string Example2::calcAnswer()
     char buf1[10];
     size_t size = 5;
 
-    // 確認用
-    int b1 = (unsigned)buf1 % 4;
-    int b2 = (unsigned)buf2 % 4;
-    printf("buf1は %d\n", b1);
-    printf("buf2は %d\n", b2);
-
-    int c = 0;
-    copyMemory(buf1, buf2, size, &c);
-    printf("%d\n", c);
+    copyMemory(buf1, buf2, size);
 
     _answer = buf1;
 
@@ -32,7 +24,7 @@ std::string Example2::calcAnswer()
     return _answer;
 }
 
-void Example2::copyMemory(void *dst, const void *src, size_t size, int *c)
+void Example2::copyMemory(void *dst, const void *src, size_t size)
 {
     /************************************
      *  memcpy(dst, src, size);
@@ -41,30 +33,18 @@ void Example2::copyMemory(void *dst, const void *src, size_t size, int *c)
                   "B Loop \t\n"
 
                   "Loop1:"
-                    "LDR r2, [%[c]] \t\n"
-                    "ADD r2, r2, #1 \t\n"
-                    "STR r2, [%[c]] \t\n"
-
                     "LDRB r0, [%[src]], #1 \t\n"
                     "STRB r0, [%[dst]], #1 \t\n"
                     "SUB %[size], %[size], #1 \t\n"
                     "B Loop \t\n"
 
                   "Loop2:"
-                    "LDR r2, [%[c]] \t\n"
-                    "ADD r2, r2, #20 \t\n"
-                    "STR r2, [%[c]] \t\n"
-
                     "LDRH r0, [%[src]], #2 \t\n"
                     "STRH r0, [%[dst]], #2 \t\n"
                     "SUB %[size], %[size], #2 \t\n"
                     "B Loop \t\n"
 
                   "Loop4:"
-                    "LDR r2, [%[c]] \t\n"
-                    "ADD r2, r2, #400 \t\n"
-                    "STR r2, [%[c]] \t\n"
-
                     "LDR r0, [%[src]], #4 \t\n"
                     "STR r0, [%[dst]], #4 \t\n"
                     "SUB %[size], %[size], #4 \t\n"
@@ -89,7 +69,7 @@ void Example2::copyMemory(void *dst, const void *src, size_t size, int *c)
                     "CMP %[size], #1 \t\n"
                     "BGE Loop1 \t\n"
                   :[dst]"+r"(dst), [src]"+r"(src), [size]"+r"(size)
-                  :[c]"r"(c)
-                  :"r0", "r1", "r2"
+                  :
+                  :"r0", "r1"
                   );
 }

--- a/Classes/Example/Example2/Example2.cpp
+++ b/Classes/Example/Example2/Example2.cpp
@@ -1,7 +1,7 @@
 #include "Example2.h"
 
 Example2::Example2()
-: _answer("")
+: _answer(nullptr)
 {
 }
 
@@ -9,15 +9,15 @@ Example2::~Example2()
 {
 }
 
-std::string& Example2::calcAnswer()
+char* Example2::calcAnswer()
 {
-    std::string buf1 = "";
-    std::string buf2 = "12345";
+    char buf1[6];
+    char buf2[6] = "12345";
     size_t size = 6;
 
     std::chrono::system_clock::time_point start = std::chrono::system_clock::now();
 
-    copyMemory(&buf1, &buf2, size);
+    copyMemory(buf1, buf2, size);
 
     std::chrono::system_clock::time_point end = std::chrono::system_clock::now();
 

--- a/Classes/Example/Example2/Example2.cpp
+++ b/Classes/Example/Example2/Example2.cpp
@@ -1,0 +1,35 @@
+#include "Example2.h"
+
+Example2::Example2()
+: _answer("")
+{
+}
+
+Example2::~Example2()
+{
+}
+
+std::string& Example2::calcAnswer()
+{
+    std::string buf1 = "";
+    std::string buf2 = "12345";
+    size_t size = 6;
+
+    std::chrono::system_clock::time_point start = std::chrono::system_clock::now();
+
+    copyMemory(&buf1, &buf2, size);
+
+    std::chrono::system_clock::time_point end = std::chrono::system_clock::now();
+
+    double elapsed = std::chrono::duration_cast<std::chrono::microseconds>(end-start).count();
+    printf("処理時間: %f[μs]\n", elapsed);
+
+    _answer = buf1;
+
+    return _answer;
+}
+
+void Example2::copyMemory(void *dst, const void *src, size_t size)
+{
+    memcpy(dst, src, size);
+}

--- a/Classes/Example/Example2/Example2.cpp
+++ b/Classes/Example/Example2/Example2.cpp
@@ -1,7 +1,7 @@
 #include "Example2.h"
 
 Example2::Example2()
-: _answer(nullptr)
+: _answer("")
 {
 }
 
@@ -9,7 +9,7 @@ Example2::~Example2()
 {
 }
 
-char* Example2::calcAnswer()
+std::string Example2::calcAnswer()
 {
     char buf1[6];
     char buf2[6] = "12345";

--- a/Classes/Example/Example2/Example2.cpp
+++ b/Classes/Example/Example2/Example2.cpp
@@ -11,13 +11,28 @@ Example2::~Example2()
 
 std::string Example2::calcAnswer()
 {
-    char buf2[10] = "123456789";
-    char buf1[10];
-    size_t size = 5;
+    char *buf2;
+    char *buf1;
+    size_t size = 1000000;
+    buf1 = (char*)malloc(size);
+    buf2 = (char*)malloc(size);
+
+    if (!buf1 || !buf2) {
+        return "メモリ確保失敗";
+    }
+
+    for (int i = 0; i < size; i++) {
+        buf2[i] = 'A';
+    }
+
+    std::chrono::system_clock::time_point start = std::chrono::system_clock::now();
 
     copyMemory(buf1, buf2, size);
 
-    _answer = buf1;
+    std::chrono::system_clock::time_point end = std::chrono::system_clock::now();
+
+    double elapsed = std::chrono::duration_cast<std::chrono::microseconds>(end-start).count();
+    printf("処理時間: %f[μs]\n", elapsed);
 
     CC_ASSERT(memcmp(buf1, buf2, size) == 0);
 

--- a/Classes/Example/Example2/Example2.cpp
+++ b/Classes/Example/Example2/Example2.cpp
@@ -48,20 +48,20 @@ void Example2::copyMemory(void *dst, const void *src, size_t size)
                   "B Loop \t\n"
 
                   "Loop1:"
-                    "LDRB r0, [%[src]], #1 \t\n"
-                    "STRB r0, [%[dst]], #1 \t\n"
+                    "LDRB r4, [%[src]], #1 \t\n"
+                    "STRB r4, [%[dst]], #1 \t\n"
                     "SUB %[size], %[size], #1 \t\n"
                     "B Loop \t\n"
 
                   "Loop2:"
-                    "LDRH r0, [%[src]], #2 \t\n"
-                    "STRH r0, [%[dst]], #2 \t\n"
+                    "LDRH r4, [%[src]], #2 \t\n"
+                    "STRH r4, [%[dst]], #2 \t\n"
                     "SUB %[size], %[size], #2 \t\n"
                     "B Loop \t\n"
 
                   "Loop4:"
-                    "LDR r0, [%[src]], #4 \t\n"
-                    "STR r0, [%[dst]], #4 \t\n"
+                    "LDR r4, [%[src]], #4 \t\n"
+                    "STR r4, [%[dst]], #4 \t\n"
                     "SUB %[size], %[size], #4 \t\n"
                     "B Loop \t\n"
 
@@ -70,14 +70,14 @@ void Example2::copyMemory(void *dst, const void *src, size_t size)
                     "CMP %[size], #4 \t\n"
                     "BLT Label_load2 \t\n"
 
-                    "ANDS r1, %[src], 0x3 \t\n"
+                    "ANDS r5, %[src], 0x3 \t\n"
                     "BEQ Loop4 \t\n"
 
                   "Label_load2:"
                     "CMP %[size], #2 \t\n"
                     "BLT Label_load1 \t\n"
 
-                    "ANDS r1, %[src], 0x1 \t\n"
+                    "ANDS r5, %[src], 0x1 \t\n"
                     "BEQ Loop2 \t\n"
 
                   "Label_load1:"
@@ -85,6 +85,6 @@ void Example2::copyMemory(void *dst, const void *src, size_t size)
                     "BGE Loop1 \t\n"
                   :[dst]"+r"(dst), [src]"+r"(src), [size]"+r"(size)
                   :
-                  :"r0", "r1"
+                  :"r4", "r5"
                   );
 }

--- a/Classes/Example/Example2/Example2.cpp
+++ b/Classes/Example/Example2/Example2.cpp
@@ -15,14 +15,7 @@ char* Example2::calcAnswer()
     char buf2[6] = "12345";
     size_t size = 6;
 
-    std::chrono::system_clock::time_point start = std::chrono::system_clock::now();
-
     copyMemory(buf1, buf2, size);
-
-    std::chrono::system_clock::time_point end = std::chrono::system_clock::now();
-
-    double elapsed = std::chrono::duration_cast<std::chrono::microseconds>(end-start).count();
-    printf("処理時間: %f[μs]\n", elapsed);
 
     _answer = buf1;
 

--- a/Classes/Example/Example2/Example2.cpp
+++ b/Classes/Example/Example2/Example2.cpp
@@ -36,10 +36,8 @@ void Example2::copyMemory(void *dst, const void *src, size_t size)
      ************************************/
     asm volatile (
                   "Loop:"
-                    "LDR r0, [%[src]] \t\n"               // srcの値をr0にロード
-                    "STR r0, [%[dst]] \t\n"               // r0をdstにストア
-                    "ADD %[src], %[src], #1 \t\n"         // src++;
-                    "ADD %[dst], %[dst], #1 \t\n"         // dst++;
+                    "LDR r0, [%[src]], #1 \t\n"               // srcの値をr0にロードしてsrc++ (post-indexed)
+                    "STR r0, [%[dst]], #1 \t\n"               // r0をdstにストアしてdst++ (post-indexed)
                     "SUB %[size], %[size], #1 \t\n"       // size--;
                     "CMP %[size], #0 \t\n"
                     "BNE Loop \t\n"                       // size != 0 がtrueならloopラベルにジャンプ

--- a/Classes/Example/Example2/Example2.h
+++ b/Classes/Example/Example2/Example2.h
@@ -14,7 +14,7 @@ public:
 private:
     std::string _answer;
 
-    void copyMemory(void *dst, const void *src, size_t size, int *c);
+    void copyMemory(void *dst, const void *src, size_t size);
 
 };
 

--- a/Classes/Example/Example2/Example2.h
+++ b/Classes/Example/Example2/Example2.h
@@ -9,10 +9,10 @@ public:
     Example2();
     virtual ~Example2();
 
-    char* calcAnswer();
+    std::string calcAnswer();
 
 private:
-    char* _answer;
+    std::string _answer;
 
     void copyMemory(void *dst, const void *src, size_t size);
 

--- a/Classes/Example/Example2/Example2.h
+++ b/Classes/Example/Example2/Example2.h
@@ -1,0 +1,21 @@
+#ifndef Example2_h
+#define Example2_h
+
+#include "cocos2d.h"
+
+class Example2
+{
+public:
+    Example2();
+    virtual ~Example2();
+
+    std::string& calcAnswer();
+
+private:
+    std::string _answer;
+
+    void copyMemory(void *dst, const void *src, size_t size);
+
+};
+
+#endif /* Example2_h */

--- a/Classes/Example/Example2/Example2.h
+++ b/Classes/Example/Example2/Example2.h
@@ -9,10 +9,10 @@ public:
     Example2();
     virtual ~Example2();
 
-    std::string& calcAnswer();
+    char* calcAnswer();
 
 private:
-    std::string _answer;
+    char* _answer;
 
     void copyMemory(void *dst, const void *src, size_t size);
 

--- a/Classes/Example/Example2/Example2.h
+++ b/Classes/Example/Example2/Example2.h
@@ -14,7 +14,7 @@ public:
 private:
     std::string _answer;
 
-    void copyMemory(void *dst, const void *src, size_t size);
+    void copyMemory(void *dst, const void *src, size_t size, int *c);
 
 };
 

--- a/Classes/HelloWorldScene.cpp
+++ b/Classes/HelloWorldScene.cpp
@@ -1,5 +1,6 @@
 #include "HelloWorldScene.h"
 #include "Example1.h"
+#include "Example2.h"
 
 USING_NS_CC;
 
@@ -35,8 +36,13 @@ void HelloWorld::onEnter()
 {
     std::string answer = "";
 
+/*** Example1
     auto example1 = new Example1();
     answer = std::to_string(example1->calcAnswer());
+ ***/
+
+    auto example2 = new Example2();
+    answer = example2->calcAnswer();
 
     _label->setString(answer);
 }

--- a/proj.ios_mac/assembly-challenge.xcodeproj/project.pbxproj
+++ b/proj.ios_mac/assembly-challenge.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		1DF5F4E00D08C38300B7A737 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
 		288765A50DF7441C002DB57D /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288765A40DF7441C002DB57D /* CoreGraphics.framework */; };
+		3056F1131EBDAA3F002127AD /* Example2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3056F1111EBDAA3F002127AD /* Example2.cpp */; };
+		3056F1141EBDACF4002127AD /* Example2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3056F1111EBDAA3F002127AD /* Example2.cpp */; };
 		3088E32C1EBC4D170084E96B /* Example1.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3088E32A1EBC4D170084E96B /* Example1.cpp */; };
 		3088E32D1EBC4F900084E96B /* Example1.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3088E32A1EBC4D170084E96B /* Example1.cpp */; };
 		3EACC98F19EE6D4300EB3C5E /* res in Resources */ = {isa = PBXBuildFile; fileRef = 3EACC98E19EE6D4300EB3C5E /* res */; };
@@ -109,6 +111,8 @@
 		1D6058910D05DD3D006BFB54 /* assembly-challenge iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "assembly-challenge iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1DF5F4DF0D08C38300B7A737 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		288765A40DF7441C002DB57D /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		3056F1111EBDAA3F002127AD /* Example2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Example2.cpp; sourceTree = "<group>"; };
+		3056F1121EBDAA3F002127AD /* Example2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Example2.h; sourceTree = "<group>"; };
 		3088E32A1EBC4D170084E96B /* Example1.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Example1.cpp; sourceTree = "<group>"; };
 		3088E32B1EBC4D170084E96B /* Example1.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Example1.h; sourceTree = "<group>"; };
 		3EACC98E19EE6D4300EB3C5E /* res */ = {isa = PBXFileReference; lastKnownFileType = folder; path = res; sourceTree = "<group>"; };
@@ -277,10 +281,20 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		3056F1101EBDAA3F002127AD /* Example2 */ = {
+			isa = PBXGroup;
+			children = (
+				3056F1111EBDAA3F002127AD /* Example2.cpp */,
+				3056F1121EBDAA3F002127AD /* Example2.h */,
+			);
+			path = Example2;
+			sourceTree = "<group>";
+		};
 		3088E3281EBC4CF80084E96B /* Example */ = {
 			isa = PBXGroup;
 			children = (
 				3088E3291EBC4CF80084E96B /* Example1 */,
+				3056F1101EBDAA3F002127AD /* Example2 */,
 			);
 			path = Example;
 			sourceTree = "<group>";
@@ -514,6 +528,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3056F1131EBDAA3F002127AD /* Example2.cpp in Sources */,
 				46880B8819C43A87006E1F66 /* AppDelegate.cpp in Sources */,
 				46880B8A19C43A87006E1F66 /* HelloWorldScene.cpp in Sources */,
 				503AE10017EB989F00D1A890 /* AppController.mm in Sources */,
@@ -527,6 +542,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3056F1141EBDACF4002127AD /* Example2.cpp in Sources */,
 				46880B8919C43A87006E1F66 /* AppDelegate.cpp in Sources */,
 				503AE10517EB98FF00D1A890 /* main.cpp in Sources */,
 				3088E32D1EBC4F900084E96B /* Example1.cpp in Sources */,


### PR DESCRIPTION
## 課題内容
- 以下のメソッドをアセンブリで書け
  - dstのアドレスへsrcのアドレスからsizeバイト分メモリをコピーする
  - ※ なるべく高速なやつをお願いします

```c
void *memcpy(void *dest, const void *src, size_t n);
```

## 変更点
- 今回からARMコンパイラ
- cocos2d-xでios実行

## 高速化
- LDR, STRのポストインデックスを使って、1命令でロードとインクリメントを同時に行った
- 32bitなので、LDRは通常4byte分ロードする
  - なので、sizeを見てできるだけ少ない命令でロードとストアを行うように条件分岐させた

## 学び
- LDR, STRには[ポストインデックス](http://mix.kumikomi.net/index.php/%E3%83%9D%E3%82%B9%E3%83%88%E3%82%A4%E3%83%B3%E3%83%87%E3%83%83%E3%82%AF%E3%82%B9%E3%83%BB%E3%82%A2%E3%83%89%E3%83%AC%E3%83%83%E3%82%B7%E3%83%B3%E3%82%B0)という使い方がある
  - ```LDR r0, [r1], #1``` とすると、r1のメモリからr0レジスタにロードを行った後、r1にオフセット(`#1`)が加算されてr1に書き戻される
  - http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0204ij/CIHGJHED.html
- ラベルは大文字から始める必要がある
- 予約語はラベルには使用できない
  - Cpy_1とかCopyとかCmpとかはダメだった
- 命令コードの接尾に条件をつけると、その条件に満たない場合は実行されない
  - SUBEQとかをやろうと思ったが、できなかった
  - http://qiita.com/edo_m18/items/a7c747c5bed600dca977
- アライメントを行わないと、byteまたぎになる場合があり、予期せぬ動作が起きる