### PR TITLE
[課題3] エンディアン変換の実装

### DIFF
--- a/Classes/Example/Example3/Example3.cpp
+++ b/Classes/Example/Example3/Example3.cpp
@@ -54,22 +54,21 @@ uint32_t Example3::swapByteAsm(uint32_t src)
 {
     asm volatile (
                   "MOV r5, #0 \t\n"
-                  "MOV r6, 0x000000ff \t\n"
 
-                  "AND r4, %[src], r6 \t\n"
+                  "AND r4, %[src], 0x000000ff \t\n"
                   "ORR r5, r5, r4, LSL #24 \t\n"
 
-                  "AND r4, %[src], r6, LSL #8 \t\n"
+                  "AND r4, %[src], 0x0000ff00 \t\n"
                   "ORR r5, r5, r4, LSL #8 \t\n"
 
-                  "AND r4, %[src], r6, LSL #16 \t\n"
+                  "AND r4, %[src], 0x00ff0000 \t\n"
                   "ORR r5, r5, r4, LSR #8 \t\n"
 
-                  "AND r4, %[src], r6, LSL #24 \t\n"
+                  "AND r4, %[src], 0xff000000 \t\n"
                   "ORR %[src], r5, r4, LSR #24 \t\n"
                   :[src]"+r"(src)
                   :
-                  :"r4", "r5", "r6"
+                  :"r4", "r5"
                   );
 
     return src;

--- a/Classes/Example/Example3/Example3.cpp
+++ b/Classes/Example/Example3/Example3.cpp
@@ -52,33 +52,25 @@ uint32_t Example3::swapByte(uint32_t src)
 
 uint32_t Example3::swapByteAsm(uint32_t src)
 {
-    uint32_t dst = 0;
-
-    char *pin  = (char*)&src;
-    char *pout = (char*)&dst;
-
     asm volatile (
-                  "LDR r4, [%[pin]] \t\n"
-                  "MOV r6, #0 \t\n"
-                  "MOV r7, 0x000000ff \t\n"
+                  "MOV r5, #0 \t\n"
+                  "MOV r6, 0x000000ff \t\n"
 
-                  "AND r5, r4, r7 \t\n"
-                  "ORR r6, r6, r5, LSL #24 \t\n"
+                  "AND r4, %[src], r6 \t\n"
+                  "ORR r5, r5, r4, LSL #24 \t\n"
 
-                  "AND r5, r4, r7, LSL #8 \t\n"
-                  "ORR r6, r6, r5, LSL #8 \t\n"
+                  "AND r4, %[src], r6, LSL #8 \t\n"
+                  "ORR r5, r5, r4, LSL #8 \t\n"
 
-                  "AND r5, r4, r7, LSL #16 \t\n"
-                  "ORR r6, r6, r5, LSR #8 \t\n"
+                  "AND r4, %[src], r6, LSL #16 \t\n"
+                  "ORR r5, r5, r4, LSR #8 \t\n"
 
-                  "AND r5, r4, r7, LSL #24 \t\n"
-                  "ORR r6, r6, r5, LSR #24 \t\n"
-
-                  "STR r6, [%[pout]] \t\n"
+                  "AND r4, %[src], r6, LSL #24 \t\n"
+                  "ORR %[src], r5, r4, LSR #24 \t\n"
+                  :[src]"+r"(src)
                   :
-                  :[pin]"r"(pin), [pout]"r"(pout)
-                  :"r4", "r5", "r6", "r7"
+                  :"r4", "r5", "r6"
                   );
 
-    return dst;
+    return src;
 }

--- a/Classes/Example/Example3/Example3.cpp
+++ b/Classes/Example/Example3/Example3.cpp
@@ -12,33 +12,39 @@ Example3::~Example3()
 std::string Example3::calcAnswer()
 {
     uint32_t src = 0x1234ABCD;
-    uint32_t dst = *swapByteAsm(&src);
+    printf("src: %08x\n", src);
 
-    printf("src: %08x\ndst: %08x\n", src, dst);
+    uint32_t dst = swapByteAsm(src);
+
+    printf("dst: %08x\n", dst);
 
     return _answer;
 }
 
-uint32_t* Example3::swapByte(uint32_t* src)
+uint32_t Example3::swapByte(uint32_t src)
 {
-    char dst[4];
-    char *p = (char*)src;
+    uint32_t dst = 0;
+
+    char *pin  = (char*)&src;
+    char *pout = ((char*)&dst) + 3;
 
     // byte swap
-    dst[3] = *p++;
-    dst[2] = *p++;
-    dst[1] = *p++;
-    dst[0] = *p;
+    for (int i = 0; i < 4; i++, pin++, pout--) {
+        *pout = *pin;
+    }
 
-    return (uint32_t*)dst;
+    return dst;
 }
 
-uint32_t* Example3::swapByteAsm(uint32_t* src)
+uint32_t Example3::swapByteAsm(uint32_t src)
 {
-    uint32_t *dst;
+    uint32_t dst = 0;
+
+    char *pin  = (char*)&src;
+    char *pout = (char*)&dst;
 
     asm volatile (
-                  "LDR r4, [%[src]] \t\n"
+                  "LDR r4, [%[pin]] \t\n"
                   "MOV r6, #0 \t\n"
                   "MOV r7, 0x000000ff \t\n"
 
@@ -54,9 +60,9 @@ uint32_t* Example3::swapByteAsm(uint32_t* src)
                   "AND r5, r4, r7, LSL #24 \t\n"
                   "ORR r6, r6, r5, LSR #24 \t\n"
 
-                  "STR r6, [%[dst]] \t\n"
+                  "STR r6, [%[pout]] \t\n"
                   :
-                  :[dst]"r"(dst), [src]"r"(src)
+                  :[pin]"r"(pin), [pout]"r"(pout)
                   :"r4", "r5", "r6", "r7"
                   );
 

--- a/Classes/Example/Example3/Example3.cpp
+++ b/Classes/Example/Example3/Example3.cpp
@@ -1,0 +1,15 @@
+#include "Example3.h"
+
+Example3::Example3()
+: _answer("")
+{
+}
+
+Example3::~Example3()
+{
+}
+
+std::string Example3::calcAnswer()
+{
+    return _answer;
+}

--- a/Classes/Example/Example3/Example3.cpp
+++ b/Classes/Example/Example3/Example3.cpp
@@ -12,11 +12,25 @@ Example3::~Example3()
 std::string Example3::calcAnswer()
 {
     uint32_t src = 0x1234ABCD;
+
     printf("src: %08x\n", src);
 
     uint32_t dst = swapByteAsm(src);
 
     printf("dst: %08x\n", dst);
+
+    auto check = [](uint32_t a, uint32_t b) {
+        char *pin  = (char*)&a;
+        char *pout = (char*)&b;
+        for (int i = 0; i < 4; i++) {
+            if (!(pin[i] == pout[3-i])) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    CC_ASSERT(check(src, dst));
 
     return _answer;
 }

--- a/Classes/Example/Example3/Example3.cpp
+++ b/Classes/Example/Example3/Example3.cpp
@@ -39,29 +39,26 @@ uint32_t* Example3::swapByteAsm(uint32_t* src)
 
     asm volatile (
                   "LDR r4, [%[src]] \t\n"
-                  "LDR r6, [%[dst]] \t\n"
+                  "MOV r6, #0 \t\n"
 
                   "AND r5, r4, 0xff \t\n"
-                  "ORR r6, r5, r6 \t\n"
-                  "LSL r6, r6, #8 \t\n"
+                  "ORR r6, r6, r5, LSL #24 \t\n"
                   "LSR r4, r4, #8 \t\n"
 
                   "AND r5, r4, 0xff \t\n"
-                  "ORR r6, r5, r6 \t\n"
-                  "LSL r6, r6, #8 \t\n"
+                  "ORR r6, r6, r5, LSL #16 \t\n"
                   "LSR r4, r4, #8 \t\n"
 
                   "AND r5, r4, 0xff \t\n"
-                  "ORR r6, r5, r6 \t\n"
-                  "LSL r6, r6, #8 \t\n"
+                  "ORR r6, r6, r5, LSL #8 \t\n"
                   "LSR r4, r4, #8 \t\n"
 
                   "AND r5, r4, 0xff \t\n"
-                  "ORR r6, r5, r6 \t\n"
+                  "ORR r6, r6, r5 \t\n"
 
                   "STR r6, [%[dst]] \t\n"
-                  :[dst]"+r"(dst), [src]"+r"(src)
                   :
+                  :[dst]"r"(dst), [src]"r"(src)
                   :"r4", "r5", "r6"
                   );
 

--- a/Classes/Example/Example3/Example3.cpp
+++ b/Classes/Example/Example3/Example3.cpp
@@ -12,7 +12,7 @@ Example3::~Example3()
 std::string Example3::calcAnswer()
 {
     uint32_t src = 0x1234ABCD;
-    uint32_t dst = *swapByte(&src);
+    uint32_t dst = *swapByteAsm(&src);
 
     printf("src: %08x\ndst: %08x\n", src, dst);
 
@@ -31,4 +31,21 @@ uint32_t* Example3::swapByte(uint32_t* src)
     dst[0] = *p;
 
     return (uint32_t*)dst;
+}
+
+uint32_t* Example3::swapByteAsm(uint32_t* src)
+{
+    uint32_t *dst;
+    char *p = (char*)src;
+
+    asm volatile (
+                  "LDR r4, [%[src]] \t\n"
+                  "REV r5, r4 \t\n"
+                  "STR r5, [%[dst]] \t\n"
+                  :[dst]"+r"(dst), [src]"+r"(src)
+                  :
+                  :"r4", "r5"
+                  );
+
+    return dst;
 }

--- a/Classes/Example/Example3/Example3.cpp
+++ b/Classes/Example/Example3/Example3.cpp
@@ -40,26 +40,24 @@ uint32_t* Example3::swapByteAsm(uint32_t* src)
     asm volatile (
                   "LDR r4, [%[src]] \t\n"
                   "MOV r6, #0 \t\n"
+                  "MOV r7, 0x000000ff \t\n"
 
-                  "AND r5, r4, 0xff \t\n"
+                  "AND r5, r4, r7 \t\n"
                   "ORR r6, r6, r5, LSL #24 \t\n"
-                  "LSR r4, r4, #8 \t\n"
 
-                  "AND r5, r4, 0xff \t\n"
-                  "ORR r6, r6, r5, LSL #16 \t\n"
-                  "LSR r4, r4, #8 \t\n"
-
-                  "AND r5, r4, 0xff \t\n"
+                  "AND r5, r4, r7, LSL #8 \t\n"
                   "ORR r6, r6, r5, LSL #8 \t\n"
-                  "LSR r4, r4, #8 \t\n"
 
-                  "AND r5, r4, 0xff \t\n"
-                  "ORR r6, r6, r5 \t\n"
+                  "AND r5, r4, r7, LSL #16 \t\n"
+                  "ORR r6, r6, r5, LSR #8 \t\n"
+
+                  "AND r5, r4, r7, LSL #24 \t\n"
+                  "ORR r6, r6, r5, LSR #24 \t\n"
 
                   "STR r6, [%[dst]] \t\n"
                   :
                   :[dst]"r"(dst), [src]"r"(src)
-                  :"r4", "r5", "r6"
+                  :"r4", "r5", "r6", "r7"
                   );
 
     return dst;

--- a/Classes/Example/Example3/Example3.cpp
+++ b/Classes/Example/Example3/Example3.cpp
@@ -11,5 +11,24 @@ Example3::~Example3()
 
 std::string Example3::calcAnswer()
 {
+    uint32_t src = 0x1234ABCD;
+    uint32_t dst = *swapByte(&src);
+
+    printf("src: %08x\ndst: %08x\n", src, dst);
+
     return _answer;
+}
+
+uint32_t* Example3::swapByte(uint32_t* src)
+{
+    char dst[4];
+    char *p = (char*)src;
+
+    // byte swap
+    dst[3] = *p++;
+    dst[2] = *p++;
+    dst[1] = *p++;
+    dst[0] = *p;
+
+    return (uint32_t*)dst;
 }

--- a/Classes/Example/Example3/Example3.cpp
+++ b/Classes/Example/Example3/Example3.cpp
@@ -53,22 +53,13 @@ uint32_t Example3::swapByte(uint32_t src)
 uint32_t Example3::swapByteAsm(uint32_t src)
 {
     asm volatile (
-                  "MOV r5, #0 \t\n"
-
-                  "AND r4, %[src], 0x000000ff \t\n"
-                  "ORR r5, r5, r4, LSL #24 \t\n"
-
-                  "AND r4, %[src], 0x0000ff00 \t\n"
-                  "ORR r5, r5, r4, LSL #8 \t\n"
-
-                  "AND r4, %[src], 0x00ff0000 \t\n"
-                  "ORR r5, r5, r4, LSR #8 \t\n"
-
-                  "AND r4, %[src], 0xff000000 \t\n"
-                  "ORR %[src], r5, r4, LSR #24 \t\n"
+                  "LDR r4, =0xff00ff00 \t\n"
+                  "AND r5, r4, %[src], ROR #8  \t\n"
+                  "AND r6, r4, %[src], ROR #16 \t\n"
+                  "ORR %[src], r5, r6, LSR #8  \t\n"
                   :[src]"+r"(src)
                   :
-                  :"r4", "r5"
+                  :"r4", "r5", "r6"
                   );
 
     return src;

--- a/Classes/Example/Example3/Example3.cpp
+++ b/Classes/Example/Example3/Example3.cpp
@@ -36,15 +36,33 @@ uint32_t* Example3::swapByte(uint32_t* src)
 uint32_t* Example3::swapByteAsm(uint32_t* src)
 {
     uint32_t *dst;
-    char *p = (char*)src;
 
     asm volatile (
                   "LDR r4, [%[src]] \t\n"
-                  "REV r5, r4 \t\n"
-                  "STR r5, [%[dst]] \t\n"
+                  "LDR r6, [%[dst]] \t\n"
+
+                  "AND r5, r4, 0xff \t\n"
+                  "ORR r6, r5, r6 \t\n"
+                  "LSL r6, r6, #8 \t\n"
+                  "LSR r4, r4, #8 \t\n"
+
+                  "AND r5, r4, 0xff \t\n"
+                  "ORR r6, r5, r6 \t\n"
+                  "LSL r6, r6, #8 \t\n"
+                  "LSR r4, r4, #8 \t\n"
+
+                  "AND r5, r4, 0xff \t\n"
+                  "ORR r6, r5, r6 \t\n"
+                  "LSL r6, r6, #8 \t\n"
+                  "LSR r4, r4, #8 \t\n"
+
+                  "AND r5, r4, 0xff \t\n"
+                  "ORR r6, r5, r6 \t\n"
+
+                  "STR r6, [%[dst]] \t\n"
                   :[dst]"+r"(dst), [src]"+r"(src)
                   :
-                  :"r4", "r5"
+                  :"r4", "r5", "r6"
                   );
 
     return dst;

--- a/Classes/Example/Example3/Example3.h
+++ b/Classes/Example/Example3/Example3.h
@@ -1,0 +1,18 @@
+#ifndef Example3_h
+#define Example3_h
+
+#include "cocos2d.h"
+
+class Example3
+{
+public:
+    Example3();
+    virtual ~Example3();
+
+    std::string calcAnswer();
+
+private:
+    std::string _answer;
+};
+
+#endif /* Example3_h */

--- a/Classes/Example/Example3/Example3.h
+++ b/Classes/Example/Example3/Example3.h
@@ -12,6 +12,8 @@ public:
     std::string calcAnswer();
 
 private:
+    uint32_t* swapByte(uint32_t* src);
+
     std::string _answer;
 };
 

--- a/Classes/Example/Example3/Example3.h
+++ b/Classes/Example/Example3/Example3.h
@@ -12,8 +12,8 @@ public:
     std::string calcAnswer();
 
 private:
-    uint32_t* swapByte(uint32_t* src);
-    uint32_t* swapByteAsm(uint32_t* src);
+    uint32_t swapByte(uint32_t src);
+    uint32_t swapByteAsm(uint32_t src);
 
     std::string _answer;
 };

--- a/Classes/Example/Example3/Example3.h
+++ b/Classes/Example/Example3/Example3.h
@@ -13,6 +13,7 @@ public:
 
 private:
     uint32_t* swapByte(uint32_t* src);
+    uint32_t* swapByteAsm(uint32_t* src);
 
     std::string _answer;
 };

--- a/Classes/HelloWorldScene.cpp
+++ b/Classes/HelloWorldScene.cpp
@@ -1,6 +1,7 @@
 #include "HelloWorldScene.h"
 #include "Example1.h"
 #include "Example2.h"
+#include "Example3.h"
 
 USING_NS_CC;
 
@@ -40,9 +41,13 @@ void HelloWorld::onEnter()
     auto example1 = new Example1();
     answer = std::to_string(example1->calcAnswer());
  ***/
-
+/*** Example2
     auto example2 = new Example2();
     answer = example2->calcAnswer();
+ ***/
+
+    auto example3 = new Example3();
+    answer = example3->calcAnswer();
 
     _label->setString(answer);
 }

--- a/proj.ios_mac/assembly-challenge.xcodeproj/project.pbxproj
+++ b/proj.ios_mac/assembly-challenge.xcodeproj/project.pbxproj
@@ -67,6 +67,8 @@
 		BF171245129291EC00B8313A /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF170DB012928DE900B8313A /* OpenGLES.framework */; };
 		BF1712471292920000B8313A /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = BF170DB412928DE900B8313A /* libz.dylib */; };
 		BF1C47F01293687400B63C5D /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF1C47EA1293683800B63C5D /* QuartzCore.framework */; };
+		CBB71D501EDA9BFD002DCA38 /* Example3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CBB71D4E1EDA9BFD002DCA38 /* Example3.cpp */; };
+		CBB71D511EDA9BFD002DCA38 /* Example3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CBB71D4E1EDA9BFD002DCA38 /* Example3.cpp */; };
 		D44C620C132DFF330009C878 /* OpenAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D44C620B132DFF330009C878 /* OpenAL.framework */; };
 		D44C620E132DFF430009C878 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D44C620D132DFF430009C878 /* AVFoundation.framework */; };
 		D44C6210132DFF4E0009C878 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D44C620F132DFF4E0009C878 /* AudioToolbox.framework */; };
@@ -163,6 +165,8 @@
 		BF170DB012928DE900B8313A /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = System/Library/Frameworks/OpenGLES.framework; sourceTree = SDKROOT; };
 		BF170DB412928DE900B8313A /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
 		BF1C47EA1293683800B63C5D /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		CBB71D4E1EDA9BFD002DCA38 /* Example3.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Example3.cpp; sourceTree = "<group>"; };
+		CBB71D4F1EDA9BFD002DCA38 /* Example3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Example3.h; sourceTree = "<group>"; };
 		D44C620B132DFF330009C878 /* OpenAL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenAL.framework; path = System/Library/Frameworks/OpenAL.framework; sourceTree = SDKROOT; };
 		D44C620D132DFF430009C878 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		D44C620F132DFF4E0009C878 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
@@ -295,6 +299,7 @@
 			children = (
 				3088E3291EBC4CF80084E96B /* Example1 */,
 				3056F1101EBDAA3F002127AD /* Example2 */,
+				CBB71D4D1EDA9BFD002DCA38 /* Example3 */,
 			);
 			path = Example;
 			sourceTree = "<group>";
@@ -380,6 +385,15 @@
 			name = Icons;
 			path = ios;
 			sourceTree = SOURCE_ROOT;
+		};
+		CBB71D4D1EDA9BFD002DCA38 /* Example3 */ = {
+			isa = PBXGroup;
+			children = (
+				CBB71D4E1EDA9BFD002DCA38 /* Example3.cpp */,
+				CBB71D4F1EDA9BFD002DCA38 /* Example3.h */,
+			);
+			path = Example3;
+			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
@@ -532,6 +546,7 @@
 				46880B8819C43A87006E1F66 /* AppDelegate.cpp in Sources */,
 				46880B8A19C43A87006E1F66 /* HelloWorldScene.cpp in Sources */,
 				503AE10017EB989F00D1A890 /* AppController.mm in Sources */,
+				CBB71D501EDA9BFD002DCA38 /* Example3.cpp in Sources */,
 				503AE10217EB989F00D1A890 /* RootViewController.mm in Sources */,
 				3088E32C1EBC4D170084E96B /* Example1.cpp in Sources */,
 				503AE10117EB989F00D1A890 /* main.m in Sources */,
@@ -546,6 +561,7 @@
 				46880B8919C43A87006E1F66 /* AppDelegate.cpp in Sources */,
 				503AE10517EB98FF00D1A890 /* main.cpp in Sources */,
 				3088E32D1EBC4F900084E96B /* Example1.cpp in Sources */,
+				CBB71D511EDA9BFD002DCA38 /* Example3.cpp in Sources */,
 				46880B8B19C43A87006E1F66 /* HelloWorldScene.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
## 課題内容
- エンディアン変換をアセンブラで実装する
  - ABCDの内、Dが一番小さい
  - int endian_transform(int a)(int: 32bit)
- ARMにあるエンディアン変換の命令は使わないこと
  - なるべく効率の良いものを実装すること

#### ヒント
- 4命令で書ける

#### エンディアン変換(バイトオーダー)について
データ保存環境のエンディアンとデータ読込環境のエンディアンが異なれば、保存時に意図したデータとは異なるデータになってしまう。
そのため、エンディアン変換を行う。

ちなみに、
小さいものから上に入れるのを、リトルエンディアン
大きいものから上に入れるのを、ビックエンディアン と言う。

## 変更点
- シフト演算を駆使して、必要な部分のビットパターンのみを抽出
  - この抽出をRORによって2倍の効率にした
  - 2つのレジスタにそれぞれ入れる
- 2つのレジスタに入っている値を最後にORRで結合する

## 学び
- ARMでエンディアン変換の命令は一応ある -> [REV](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0489ej/Cihjgdid.html)
- [フレキシブル第2オペランド](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0204ij/Cihbeage.html)
  - Operand2 と表記されている部分は定数を入れることもできるが、レジスタに格納されたビットパターンをシフトまたはロテートさせることもできる
- [即値で32bitを入れる方法](http://d.hatena.ne.jp/natsutan/20080411/1207920875)
  - 1命令全てを合わせて32bitなので通常は即値で32bitは入らない
  - それを疑似命令で可能とする
- ローテートを使って、同時に2byteを移動させる
  - シフト演算をうまく使う